### PR TITLE
Docs(privacy): introduce privacy policy for CWS approval

### DIFF
--- a/PRIVACY_POLICY.md
+++ b/PRIVACY_POLICY.md
@@ -1,0 +1,21 @@
+# Privacy Policy for CF FetchCodes
+
+**Effective Date:** 15th July 2026
+
+CF FetchCodes ("we", "our", or "the extension") is committed to protecting your privacy. This Privacy Policy explains how we collect, use, and handle your information when you use our browser extension.
+
+**1. Data Collection and Usage**
+*   **Gemini API Key:** The extension requires a Google Gemini API key to power its AI explainer features. This key is saved locally in your browser using `chrome.storage.local`. We do not collect, transmit, or store this key on any external servers. It is used exclusively to make direct API calls to Google's AI services from your browser.
+*   **Codeforces Data:** The extension reads public data from Codeforces.com (such as your username, friends list, and public submissions) to display them in the interface. This data is processed locally in your browser and is not sent to any external servers other than Codeforces.com and the Google Gemini API (when you request an AI explanation).
+
+**2. Data Sharing**
+We do not sell, trade, or otherwise transfer your personal information or API keys to outside parties.
+
+**3. Analytics and Tracking**
+The extension does not use any third-party analytics, tracking cookies, or background monitoring.
+
+**4. Changes to This Policy**
+We may update this Privacy Policy from time to time. Any changes will be posted on this page.
+
+**5. Contact Us**
+If you have any questions about this Privacy Policy, please contact us at: sayanpauldeveloper@gmail.com or by opening an issue on our GitHub repository.


### PR DESCRIPTION
# Docs(privacy): introduce privacy policy for CWS approval

- Add PRIVACY_POLICY.md detailing local storage of API keys and data usage.
- Required to pass Chrome Web Store review for extensions handling sensitive user data.